### PR TITLE
Arbitrum testnet fix (#186)

### DIFF
--- a/apps/dapp/package.json
+++ b/apps/dapp/package.json
@@ -19,7 +19,7 @@
     "postinstall": "yarn codegen"
   },
   "dependencies": {
-    "@bond-protocol/bond-library": "^0.1.12",
+    "@bond-protocol/bond-library": "^0.1.13",
     "@bond-protocol/contract-library": "*",
     "@esbuild-plugins/node-globals-polyfill": "^0.1.1",
     "@material-tailwind/react": "^1.0.6",

--- a/apps/dapp/src/components/organisms/IssuerList.tsx
+++ b/apps/dapp/src/components/organisms/IssuerList.tsx
@@ -7,7 +7,6 @@ import { useAtom } from "jotai";
 import testnetMode from "../../atoms/testnetMode.atom";
 import { useOwnerTokenTbvs } from "hooks/useOwnerTokenTbvs";
 import { useNavigate } from "react-router-dom";
-import { socials } from "..";
 
 export const IssuerList = () => {
   const { marketsByIssuer, issuers } = useMarkets();
@@ -70,7 +69,6 @@ export const IssuerList = () => {
     currentSort.sortBy();
   }, [issuers, marketsByIssuer, protocolTbvs, search]);
 
-  console.log({ sortedIssuers });
   return (
     <>
       {/* hiding search for now as there'll be little partners
@@ -83,26 +81,21 @@ export const IssuerList = () => {
       </p>
         */}
       <div className="mt-8 flex flex-wrap gap-x-12 gap-y-10">
-        {sortedIssuers
-          .filter((issuer) => issuer?.links?.twitter !== socials.twitter)
-          .map((issuer) => {
-            if (
-              issuer.name &&
-              issuer.name.toLowerCase().indexOf(search) != -1
-            ) {
-              const markets = marketsByIssuer.get(issuer.id) || [];
-              return (
-                <div key={issuer.id} className="w-full flex-1">
-                  <IssuerCard
-                    issuer={issuer}
-                    tbv={protocolTbvs?.get(issuer.id) || 0}
-                    markets={markets}
-                    navigate={navigate}
-                  />
-                </div>
-              );
-            }
-          })}
+        {sortedIssuers.map((issuer) => {
+          if (issuer.name && issuer.name.toLowerCase().indexOf(search) != -1) {
+            const markets = marketsByIssuer.get(issuer.id) || [];
+            return (
+              <div key={issuer.id} className="w-full flex-1">
+                <IssuerCard
+                  issuer={issuer}
+                  tbv={protocolTbvs?.get(issuer.id) || 0}
+                  markets={markets}
+                  navigate={navigate}
+                />
+              </div>
+            );
+          }
+        })}
       </div>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1522,10 +1522,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bond-protocol/bond-library@^0.1.12":
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/@bond-protocol/bond-library/-/bond-library-0.1.12.tgz#07e07bedd1c080e8d0eba069368fde51b5ff42bb"
-  integrity sha512-j2yEFq2uge8H0RxEGrDN0THYsPsm5ifye03ucJh6yf7VpXmL1GGB9gXs6m356AgT1HWZGZoRWLGbmE/fvlkjUg==
+"@bond-protocol/bond-library@^0.1.13":
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/@bond-protocol/bond-library/-/bond-library-0.1.13.tgz#d2e8dceda90db0f9b21e2fe20315c926f22b90c4"
+  integrity sha512-dMbyV+TnweJUT+Tga8fNCeeo9rcw/okQaKUy4TVQ/nxbHO85Y6BLJ/3ULbLkh0qh94l+16z302zVdj20+eVa1w==
   dependencies:
     axios "^0.27.2"
     ethers "^5.6.8"


### PR DESCRIPTION
* Revert "hacky fix to remove bp for now"

This reverts commit c8498d867bf545a8967c28ff0f707af7424549b4.

* Update bond-library version (fixes arbitrum goerli being set as mainnet)