### PR TITLE
Arbitrum mainnet (#192)

### DIFF
--- a/apps/dapp/src/components/organisms/BondDetails.tsx
+++ b/apps/dapp/src/components/organisms/BondDetails.tsx
@@ -93,6 +93,7 @@ export const BondDetails: FC<BondDetailsProps> = ({
     if (
       market.network === network?.chain?.network ||
       (market.network === "mainnet" && network?.chain?.network === "homestead") ||
+      (market.network === "arbitrum-one" && network?.chain?.network === "arbitrum") ||
       (market.network === "arbitrum-goerli" && network?.chain?.network === "arbitrumGoerli")
     ) {
       setCorrectChain(true);

--- a/apps/dapp/src/context/evm-provider.tsx
+++ b/apps/dapp/src/context/evm-provider.tsx
@@ -20,7 +20,7 @@ import { environment } from "src/env-state";
 const isTestnet = !environment.isProduction;
 
 const { chains, provider } = configureChains(
-  isTestnet ? [chain.goerli, chain.arbitrumGoerli] : [chain.mainnet],
+  isTestnet ? [chain.goerli, chain.arbitrumGoerli] : [chain.mainnet, chain.arbitrum],
   [publicProvider()]
 );
 

--- a/apps/dapp/src/graphql/queries.ts
+++ b/apps/dapp/src/graphql/queries.ts
@@ -102,6 +102,57 @@ export const listMarketsGoerli = gql`
   }
 `;
 
+export const listMarketsArbitrumMainnet = gql`
+  query ListMarketsArbitrumMainnet($addresses: [String!]!) {
+    markets(where: { isLive: true, owner_in: $addresses }) {
+      id
+      name
+      network
+      auctioneer
+      teller
+      marketId
+      owner
+      payoutToken {
+        id
+        address
+        symbol
+        decimals
+        name
+      }
+      quoteToken {
+        id
+        address
+        symbol
+        decimals
+        name
+        lpPair {
+          token0 {
+            id
+            address
+            symbol
+            decimals
+            name
+          }
+          token1 {
+            id
+            address
+            symbol
+            decimals
+            name
+          }
+        }
+      }
+      vesting
+      vestingType
+      isInstantSwap
+      isLive
+      totalBondedAmount
+      totalPayoutAmount
+      creationBlockTimestamp
+    }
+  }
+`;
+
 export const listMarketsArbitrumGoerli = gql`
   query ListMarketsArbitrumGoerli($addresses: [String!]!) {
     markets(where: { isLive: true, owner_in: $addresses }) {
@@ -195,6 +246,27 @@ export const listTokensGoerli = gql`
   }
 `;
 
+export const listTokensArbitrumMainnet = gql`
+  query ListTokensArbitrumMainnet {
+    tokens {
+      id
+      network
+      address
+      decimals
+      symbol
+      name
+      lpPair {
+        token0 {
+          id
+        }
+        token1 {
+          id
+        }
+      }
+    }
+  }
+`;
+
 export const listTokensArbitrumGoerli = gql`
   query ListTokensArbitrumGoerli {
     tokens {
@@ -244,6 +316,32 @@ export const getOwnerBalancesByOwnerMainnet = gql`
 
 export const getOwnerBalancesByOwnerGoerli = gql`
   query GetOwnerBalancesByOwnerGoerli($owner: String!) {
+    ownerBalances(where: { owner_contains_nocase: $owner, balance_gt: 0 }) {
+      id
+      tokenId
+      owner
+      balance
+      network
+      bondToken {
+        id
+        symbol
+        decimals
+        expiry
+        network
+        type
+        teller
+        underlying {
+          id
+          symbol
+          decimals
+        }
+      }
+    }
+  }
+`;
+
+export const getOwnerBalancesByOwnerArbitrumMainnet = gql`
+  query GetOwnerBalancesByOwnerArbitrumMainnet($owner: String!) {
     ownerBalances(where: { owner_contains_nocase: $owner, balance_gt: 0 }) {
       id
       tokenId
@@ -396,6 +494,57 @@ export const listOwnedMarketsGoerli = gql`
   }
 `;
 
+export const listOwnedMarketsArbitrumMainnet = gql`
+  query ListOwnedMarketsArbitrumMainnet($owner: String!) {
+    markets(where: { owner_contains_nocase: $owner }) {
+      id
+      name
+      network
+      auctioneer
+      teller
+      marketId
+      owner
+      payoutToken {
+        id
+        address
+        symbol
+        decimals
+        name
+      }
+      quoteToken {
+        id
+        address
+        symbol
+        decimals
+        name
+        lpPair {
+          token0 {
+            id
+            address
+            symbol
+            decimals
+            name
+          }
+          token1 {
+            id
+            address
+            symbol
+            decimals
+            name
+          }
+        }
+      }
+      vesting
+      vestingType
+      isInstantSwap
+      isLive
+      totalBondedAmount
+      totalPayoutAmount
+      creationBlockTimestamp
+    }
+  }
+`;
+
 export const listOwnedMarketsArbitrumGoerli = gql`
   query ListOwnedMarketsArbitrumGoerli($owner: String!) {
     markets(where: { owner_contains_nocase: $owner }) {
@@ -490,6 +639,25 @@ export const listErc20BondTokensGoerli = gql`
   }
 `;
 
+export const listErc20BondTokensArbitrumMainnet = gql`
+  query ListErc20BondTokensArbitrumMainnet {
+    bondTokens(where: { type: "fixed-expiration" }) {
+      id
+      symbol
+      decimals
+      underlying {
+        id
+        symbol
+        decimals
+      }
+      expiry
+      teller
+      network
+      type
+    }
+  }
+`;
+
 export const listErc20BondTokensArbitrumGoerli = gql`
   query ListErc20BondTokensArbitrumGoerli {
     bondTokens(where: { type: "fixed-expiration" }) {
@@ -525,6 +693,14 @@ export const listUniqueBondersGoerli = gql`
   }
 `;
 
+export const listUniqueBondersArbitrumMainnet = gql`
+  query ListUniqueBondersArbitrumMainnet {
+    uniqueBonders {
+      id
+    }
+  }
+`;
+
 export const listUniqueBondersArbitrumGoerli = gql`
   query ListUniqueBondersArbitrumGoerli {
     uniqueBonders {
@@ -553,6 +729,24 @@ export const listBondPurchasesMainnet = gql`
 
 export const listBondPurchasesGoerli = gql`
   query ListBondPurchasesGoerli($addresses: [String!]!) {
+    bondPurchases(first: 1000, where: { owner_in: $addresses }) {
+      id
+      marketId
+      owner
+      amount
+      payout
+      recipient
+      timestamp
+      network
+      quoteToken {
+        id
+      }
+    }
+  }
+`;
+
+export const listBondPurchasesArbitrumMainnet = gql`
+  query ListBondPurchasesArbitrumMainnet($addresses: [String!]!) {
     bondPurchases(first: 1000, where: { owner_in: $addresses }) {
       id
       marketId
@@ -609,6 +803,17 @@ export const listOwnerTokenTbvsGoerli = gql`
   }
 `;
 
+export const listOwnerTokenTbvsArbitrumMainnet = gql`
+  query ListOwnerTokenTbvsArbitrumMainnet {
+    ownerTokenTbvs(first: 1000) {
+      owner
+      token
+      tbv
+      network
+    }
+  }
+`;
+
 export const listOwnerTokenTbvsArbitrumGoerli = gql`
   query ListOwnerTokenTbvsArbitrumGoerli {
     ownerTokenTbvs(first: 1000) {
@@ -620,8 +825,83 @@ export const listOwnerTokenTbvsArbitrumGoerli = gql`
   }
 `;
 
-export const listBondPurchasesPerMarket = gql`
-  query ListBondPurchasesPerMarket($marketId: String) {
+export const listBondPurchasesPerMarketMainnet = gql`
+  query ListBondPurchasesPerMarketMainnet($marketId: String) {
+    bondPurchases(where: { marketId: $marketId }, orderBy: timestamp) {
+      id
+      payout
+      amount
+      timestamp
+      purchasePrice
+      postPurchasePrice
+      quoteToken {
+        id
+        name
+        symbol
+        address
+      }
+      payoutToken {
+        id
+        name
+        symbol
+        address
+      }
+    }
+  }
+`;
+
+export const listBondPurchasesPerMarketGoerli = gql`
+  query ListBondPurchasesPerMarketGoerli($marketId: String) {
+    bondPurchases(where: { marketId: $marketId }, orderBy: timestamp) {
+      id
+      payout
+      amount
+      timestamp
+      purchasePrice
+      postPurchasePrice
+      quoteToken {
+        id
+        name
+        symbol
+        address
+      }
+      payoutToken {
+        id
+        name
+        symbol
+        address
+      }
+    }
+  }
+`;
+
+export const listBondPurchasesPerMarketArbitrumMainnet = gql`
+  query ListBondPurchasesPerMarketArbitrumMainnet($marketId: String) {
+    bondPurchases(where: { marketId: $marketId }, orderBy: timestamp) {
+      id
+      payout
+      amount
+      timestamp
+      purchasePrice
+      postPurchasePrice
+      quoteToken {
+        id
+        name
+        symbol
+        address
+      }
+      payoutToken {
+        id
+        name
+        symbol
+        address
+      }
+    }
+  }
+`;
+
+export const listBondPurchasesPerMarketArbitrumGoerli = gql`
+  query ListBondPurchasesPerMarketArbitrumGoerli($marketId: String) {
     bondPurchases(where: { marketId: $marketId }, orderBy: timestamp) {
       id
       payout

--- a/apps/dapp/src/hooks/useBondChartData.ts
+++ b/apps/dapp/src/hooks/useBondChartData.ts
@@ -1,8 +1,8 @@
 import { useQuery } from "react-query";
 import {
   BondPurchase,
-  ListBondPurchasesPerMarketQuery,
-  useListBondPurchasesPerMarketQuery,
+  ListBondPurchasesPerMarketMainnetQuery,
+  useListBondPurchasesPerMarketMainnetQuery,
 } from "../generated/graphql";
 import { CalculatedMarket } from "@bond-protocol/contract-library";
 import { subgraphEndpoints } from "services/subgraph-endpoints";
@@ -17,7 +17,7 @@ type PriceDataArray = Array<{ date: number; price: number }>;
 
 type CreateBondPurchaseDatasetArgs = {
   priceData: PriceDataArray;
-} & Pick<ListBondPurchasesPerMarketQuery, "bondPurchases">;
+} & Pick<ListBondPurchasesPerMarketMainnetQuery, "bondPurchases">;
 
 const getMarketPriceAtPurchaseTime = (
   timestamp: number,
@@ -88,7 +88,7 @@ export const useBondChartData = (market: CalculatedMarket, dayRange = 3) => {
   );
 
   const { data: purchaseData, ...purchasesQuery } =
-    useListBondPurchasesPerMarketQuery(
+    useListBondPurchasesPerMarketMainnetQuery(
       { endpoint: subgraphEndpoints[market.network as CHAIN_ID] },
       { marketId: market.id }
     );

--- a/apps/dapp/src/hooks/useLoadMarkets.tsx
+++ b/apps/dapp/src/hooks/useLoadMarkets.tsx
@@ -3,7 +3,8 @@ import {
   Market,
   useListMarketsGoerliQuery,
   useListMarketsMainnetQuery,
-  useListMarketsArbitrumGoerliQuery
+  useListMarketsArbitrumGoerliQuery,
+  useListMarketsArbitrumMainnetQuery
 } from "../generated/graphql";
 import { useEffect, useState } from "react";
 import { useAtom } from "jotai";
@@ -31,6 +32,12 @@ export function useLoadMarkets() {
     { enabled: !!testnet }
   );
 
+  const { data: arbitrumMainnetData, ...arbitrumMainnetQuery } = useListMarketsArbitrumMainnetQuery(
+    { endpoint: endpoints[2] },
+    { addresses: getAddressesByChain(CHAIN_ID.ARBITRUM_MAINNET) },
+    { enabled: !testnet }
+  );
+
   const { data: arbitrumGoerliData, ...arbitrumGoerliQuery } = useListMarketsArbitrumGoerliQuery(
     { endpoint: endpoints[3] },
     { addresses: getAddressesByChain(CHAIN_ID.ARBITRUM_GOERLI_TESTNET) },
@@ -39,12 +46,14 @@ export function useLoadMarkets() {
 
   useEffect(() => {
     if (testnet) return;
-    if (mainnetData && mainnetData.markets) {
-      const allMarkets = mainnetData.markets;
+    if (mainnetData && mainnetData.markets && arbitrumMainnetData && arbitrumMainnetData.markets) {
+      const allMarkets =
+        mainnetData.markets
+          .concat(arbitrumMainnetData.markets);
       // @ts-ignore
       setMainnetMarkets(allMarkets);
     }
-  }, [mainnetData, testnet]);
+  }, [mainnetData, arbitrumMainnetData, testnet]);
 
   useEffect(() => {
     if (!testnet) return;
@@ -74,7 +83,7 @@ export function useLoadMarkets() {
 
   const isLoading = testnet
     ? (goerliQuery.isLoading || arbitrumGoerliQuery.isLoading)
-    : mainnetQuery.isLoading;
+    : (mainnetQuery.isLoading || arbitrumMainnetQuery.isLoading);
 
   return {
     markets: selectedMarkets,

--- a/apps/dapp/src/hooks/useMyMarkets.tsx
+++ b/apps/dapp/src/hooks/useMyMarkets.tsx
@@ -1,6 +1,8 @@
 import { getSubgraphEndpoints } from "services/subgraph-endpoints";
 import {
-  Market, useListOwnedMarketsArbitrumGoerliQuery,
+  Market,
+  useListOwnedMarketsArbitrumGoerliQuery,
+  useListOwnedMarketsArbitrumMainnetQuery,
   useListOwnedMarketsGoerliQuery,
   useListOwnedMarketsMainnetQuery,
 } from "../generated/graphql";
@@ -31,6 +33,13 @@ export function useMyMarkets() {
     { enabled: !!testnet }
   );
 
+  const { data: arbitrumMainnetData, ...arbitrumMainnetQuery } =
+    useListOwnedMarketsArbitrumMainnetQuery(
+      { endpoint: endpoints[2] },
+      { owner: address || "0x0000000000000000" },
+      { enabled: !testnet }
+    );
+
   const { data: arbitrumGoerliData, ...arbitrumGoerliQuery } = useListOwnedMarketsArbitrumGoerliQuery(
     { endpoint: endpoints[3] },
     { owner: address || "0x0000000000000000" },
@@ -39,12 +48,14 @@ export function useMyMarkets() {
 
   useEffect(() => {
     if (testnet) return;
-    if (mainnetData && mainnetData.markets) {
-      const allMarkets = mainnetData.markets;
+    if (mainnetData && mainnetData.markets && arbitrumMainnetData && arbitrumMainnetData.markets) {
+      const allMarkets =
+        mainnetData.markets
+          .concat(arbitrumMainnetData.markets);
       // @ts-ignore
       setMainnetMarkets(allMarkets);
     }
-  }, [mainnetData, testnet]);
+  }, [mainnetData, arbitrumMainnetData, testnet]);
 
   useEffect(() => {
     if (!testnet) return;
@@ -66,8 +77,8 @@ export function useMyMarkets() {
   }, [testnet, mainnetMarkets, testnetMarkets]);
 
   const isLoading = testnet
-    ? goerliQuery.isLoading || arbitrumGoerliQuery.isLoading
-    : mainnetQuery.isLoading;
+    ? (goerliQuery.isLoading || arbitrumGoerliQuery.isLoading)
+    : (mainnetQuery.isLoading || arbitrumMainnetQuery.isLoading);
 
   return {
     markets: selectedMarkets,

--- a/apps/dapp/src/hooks/useOwnerTokenTbvs.tsx
+++ b/apps/dapp/src/hooks/useOwnerTokenTbvs.tsx
@@ -5,6 +5,7 @@ import testnetMode from "../atoms/testnetMode.atom";
 import {
   OwnerTokenTbv,
   useListOwnerTokenTbvsArbitrumGoerliQuery,
+  useListOwnerTokenTbvsArbitrumMainnetQuery,
   useListOwnerTokenTbvsGoerliQuery,
   useListOwnerTokenTbvsMainnetQuery,
 } from "../generated/graphql";
@@ -34,6 +35,13 @@ export function useOwnerTokenTbvs() {
       {enabled: !!testnet}
     );
 
+  const {data: arbitrumMainnetData, ...arbitrumMainnetQuery} =
+    useListOwnerTokenTbvsArbitrumMainnetQuery(
+      {endpoint: endpoints[2]},
+      {},
+      {enabled: !testnet}
+    );
+
   const {data: arbitrumGoerliData, ...arbitrumGoerliQuery} =
     useListOwnerTokenTbvsArbitrumGoerliQuery(
       {endpoint: endpoints[3]},
@@ -43,12 +51,14 @@ export function useOwnerTokenTbvs() {
 
   useEffect(() => {
     if (testnet) return;
-    if (mainnetData && mainnetData.ownerTokenTbvs) {
-      const allOwnerTokens = mainnetData.ownerTokenTbvs;
+    if (mainnetData && mainnetData.ownerTokenTbvs && arbitrumMainnetData && arbitrumMainnetData.ownerTokenTbvs) {
+      const allOwnerTokens =
+        mainnetData.ownerTokenTbvs
+          .concat(arbitrumMainnetData.ownerTokenTbvs);
       // @ts-ignore
       setMainnetOwnerTokenTbvs(allOwnerTokens);
     }
-  }, [mainnetData, testnet]);
+  }, [mainnetData, arbitrumMainnetData, testnet]);
 
   useEffect(() => {
     if (!testnet) return;
@@ -86,7 +96,12 @@ export function useOwnerTokenTbvs() {
     setProtocolTbvs(ownerTokenTbvMap);
   }, [testnet, mainnetOwnerTokenTbvs, testnetOwnerTokenTbvs, currentPrices]);
 
+  const isLoading = testnet
+    ? (goerliQuery.isLoading || arbitrumGoerliQuery.isLoading)
+    : (mainnetQuery.isLoading || arbitrumMainnetQuery.isLoading);
+
   return {
     protocolTbvs: protocolTbvs,
+    isLoading,
   };
 }

--- a/apps/dapp/src/hooks/useTokens.tsx
+++ b/apps/dapp/src/hooks/useTokens.tsx
@@ -3,9 +3,11 @@ import { calcLpPrice, LpPair } from "@bond-protocol/contract-library";
 import { providers } from "services/owned-providers";
 import { getSubgraphEndpoints } from "services/subgraph-endpoints";
 import {
-  Token, useListTokensArbitrumGoerliQuery,
+  Token,
   useListTokensGoerliQuery,
   useListTokensMainnetQuery,
+  useListTokensArbitrumMainnetQuery,
+  useListTokensArbitrumGoerliQuery
 } from "../generated/graphql";
 import { useCallback, useEffect, useState } from "react";
 import * as bondLibrary from "@bond-protocol/bond-library";
@@ -66,6 +68,11 @@ export const useTokens = () => {
     endpoint: endpoints[1],
     // @ts-ignore
     enabled: !!testnet,
+  });
+  const { data: arbitrumMainnetData, ...arbitrumMainnetQuery } = useListTokensArbitrumMainnetQuery({
+    endpoint: endpoints[2],
+    // @ts-ignore
+    enabled: !testnet,
   });
 
   const { data: arbitrumGoerliData, ...arbitrumGoerliQuery } = useListTokensArbitrumGoerliQuery({
@@ -263,12 +270,14 @@ export const useTokens = () => {
    */
   useEffect(() => {
     if (testnet) return;
-    if (mainnetData && mainnetData.tokens) {
-      const allTokens = mainnetData.tokens;
+    if (mainnetData && mainnetData.tokens && arbitrumMainnetData && arbitrumMainnetData.tokens) {
+      const allTokens =
+        mainnetData.tokens
+          .concat(arbitrumMainnetData.tokens);
       // @ts-ignore
       setMainnetTokens(allTokens);
     }
-  }, [mainnetData, testnet]);
+  }, [mainnetData, arbitrumMainnetData, testnet]);
 
   useEffect(() => {
     if (!testnet) return;
@@ -357,7 +366,7 @@ export const useTokens = () => {
 
   const isLoading = testnet
     ? (goerliQuery.isLoading || arbitrumGoerliQuery.isLoading)
-    : mainnetQuery.isLoading;
+    : (mainnetQuery.isLoading || arbitrumMainnetQuery.isLoading);
 
   /*
   tokens:         An array of all Tokens the Subgraph has picked up on mainnet networks

--- a/apps/dapp/src/hooks/useUniqueBonders.tsx
+++ b/apps/dapp/src/hooks/useUniqueBonders.tsx
@@ -4,6 +4,7 @@ import testnetMode from "../atoms/testnetMode.atom";
 import { useEffect, useState } from "react";
 import {
   useListUniqueBondersArbitrumGoerliQuery,
+  useListUniqueBondersArbitrumMainnetQuery,
   useListUniqueBondersGoerliQuery,
   useListUniqueBondersMainnetQuery,
 } from "../generated/graphql";
@@ -23,22 +24,28 @@ export function useUniqueBonders() {
     new Map<string, number>()
   );
 
-  const { data: mainnetData } = useListUniqueBondersMainnetQuery({
+  const { data: mainnetData, ...mainnetQuery } = useListUniqueBondersMainnetQuery({
     endpoint: endpoints[0],
   });
 
-  const { data: goerliData } = useListUniqueBondersGoerliQuery({
+  const { data: goerliData, ...goerliQuery } = useListUniqueBondersGoerliQuery({
     endpoint: endpoints[1],
   });
 
-  const { data: arbitrumGoerliData } = useListUniqueBondersArbitrumGoerliQuery({
+  const { data: arbitrumMainnetData, ...arbitrumMainnetQuery } = useListUniqueBondersArbitrumMainnetQuery({
+    endpoint: endpoints[2],
+  });
+
+  const { data: arbitrumGoerliData, ...arbitrumGoerliQuery } = useListUniqueBondersArbitrumGoerliQuery({
     endpoint: endpoints[3],
   });
 
   useEffect(() => {
     if (testnet) return;
-    if (mainnetData && mainnetData.uniqueBonders) {
-      const allBonders = mainnetData.uniqueBonders;
+    if (mainnetData && mainnetData.uniqueBonders && arbitrumMainnetData && arbitrumMainnetData.uniqueBonders) {
+      const allBonders =
+        mainnetData.uniqueBonders
+          .concat(arbitrumMainnetData.uniqueBonders);
       const bonderMap = new Map();
 
       allBonders.forEach((bonder) => {
@@ -53,7 +60,7 @@ export function useUniqueBonders() {
 
       setMainnetBonders(bonderMap);
     }
-  }, [mainnetData, testnet]);
+  }, [mainnetData, arbitrumMainnetData, testnet]);
 
   useEffect(() => {
     if (!testnet) return;
@@ -98,8 +105,13 @@ export function useUniqueBonders() {
     return count;
   }
 
+  const isLoading = testnet
+    ? (goerliQuery.isLoading || arbitrumGoerliQuery.isLoading)
+    : (mainnetQuery.isLoading || arbitrumMainnetQuery.isLoading);
+
   return {
     bonders: selectedBonders,
     getBondersForProtocol: (name: string) => getBondersForProtocol(name),
+    isLoading,
   };
 }

--- a/apps/dapp/src/services/subgraph-endpoints.tsx
+++ b/apps/dapp/src/services/subgraph-endpoints.tsx
@@ -7,7 +7,7 @@ export const subgraphEndpoints = {
   [CHAIN_ID.GOERLI_TESTNET]:
     "https://api.thegraph.com/subgraphs/name/bond-protocol/bond-protocol-goerli",
   [CHAIN_ID.ARBITRUM_MAINNET]:
-    "https://api.thegraph.com/subgraphs/name/bond-protocol/bond-protocol-arbitrum",
+    "https://api.thegraph.com/subgraphs/name/bond-protocol/bond-protocol-arbitrum-mainnet",
   [CHAIN_ID.ARBITRUM_GOERLI_TESTNET]:
     "https://api.thegraph.com/subgraphs/name/bond-protocol/bond-protocol-goerli-arbitrum",
 };

--- a/packages/contract-library/src/modules/address-provider.ts
+++ b/packages/contract-library/src/modules/address-provider.ts
@@ -32,6 +32,15 @@ const goerliAddresses: ContractAddresses = {
   fixedTermAuctioneer: '0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222',
 };
 
+const arbitrumMainnetAddresses: ContractAddresses = {
+  authority: '0x007A0F48A4e3d74Ab4234adf9eA9EB32f87b4b14',
+  aggregator: '0x007A66A2a13415DB3613C1a4dd1C942A285902d1',
+  fixedExpirationTeller: '0x007FE70dc9797C4198528aE43d8195ffF82Bdc95',
+  fixedExpirationAuctioneer: '0x007FEA32545a39Ff558a1367BBbC1A22bc7ABEfD',
+  fixedTermTeller: '0x007F7735baF391e207E3aA380bb53c4Bd9a5Fed6',
+  fixedTermAuctioneer: '0x007F7A1cb838A872515c8ebd16bE4b14Ef43a222',
+};
+
 const arbitrumGoerliAddresses: ContractAddresses = {
   authority: '0x007A0F48A4e3d74Ab4234adf9eA9EB32f87b4b14',
   aggregator: '0x007A66A2a13415DB3613C1a4dd1C942A285902d1',
@@ -47,6 +56,8 @@ const addressesByChain: { [key: string]: ContractAddresses } = {
   'homestead': mainnetAddresses,
   '5': goerliAddresses,
   'goerli': goerliAddresses,
+  '42161': arbitrumMainnetAddresses,
+  'arbitrum': arbitrumMainnetAddresses,
   '421613': arbitrumGoerliAddresses,
   'arbitrum-goerli': arbitrumGoerliAddresses,
   'arbitrumGoerli': arbitrumGoerliAddresses,


### PR DESCRIPTION
* Add arbitrum mainnet graphql queries + missing bond purchases queries

* Update hooks

* Add Arbitrum to address-provider and evm-provider

* Rename bondExpiry -> bondVesting, expiryDate -> vesting

* Add vesting date note

* Update arbitrum mainnet subgraph endpoint

* Use bond-library 0.1.15

* Check for mismatch in subgraph/wallet names for arbitrum mainnet

* Fix create market page chain not repopulating on edit

* Fix create market page token prices not updating

* Rename payoutTokenAddress/quoteTokenAddress -> payoutToken/quoteToken