### PR TITLE
remove build script. directly import

### DIFF
--- a/apps/dapp/package.json
+++ b/apps/dapp/package.json
@@ -50,6 +50,7 @@
     "tailwindconfig": "*",
     "tailwindcss": "^3.3.2",
     "tsconfig": "*",
+    "types": "*",
     "ui": "*",
     "use-deep-compare-effect": "^1.8.1",
     "viem": "1.17.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "engines": {
     "node": ">=16.19"
   },
-  "packageManager": "yarn",
+  "packageManager": "yarn@1.22.19",
   "workspaces": [
     "apps/*",
     "packages/*",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,11 +3,7 @@
   "version": "0.0.1",
   "description": "Reusable protocol-specific types",
   "license": "MIT",
-  "main": "./dist/src/index.js",
-  "files": [
-    "dist"
-  ],
-  "scripts": {
-    "build": "tsc --build"
-  }
+  "type": "module",
+  "private": true,
+  "main": "./src/index.ts"
 }


### PR DESCRIPTION
you may need to remove node_modules and reinstall after this change.
but in general this pattern allows us to not have to build packages in our workspace. We can just directly import. 